### PR TITLE
IdSessionCreateOptions: Change allowedProviders type

### DIFF
--- a/src/services/identificationv2/model/IdSessionCreateOptions.ts
+++ b/src/services/identificationv2/model/IdSessionCreateOptions.ts
@@ -53,7 +53,7 @@ export interface IdSessionCreateOptions {
 
 export namespace IdSessionCreateOptions {
   export type IdProviderType = 'no_bankid_netcentric' | 'no_bankid_mobile' | 'se_bankid' | 'no_buypass' | 'dk_nemid' |
-    'fi_eid' | 'sms_otp' | 'freja' | 'github' | 'google' | ' linkedin';
+    'ftn' | 'sms_otp' | 'freja' | 'github' | 'google' | ' linkedin';
 
   export type Language = 'en' | 'no' | 'sv' | 'da' | 'fi' | 'de';
 


### PR DESCRIPTION
Changed `fi_eid` to `ftn` from allowedProviders as `fi_eid` option is
not working with Signicat API. 

When using `fi_eid` as allowed provider,
the API responds with 400 status saying with the following errors:

```
field: 'allowedProviders[0]',
message: 'Field contains an invalid value. See documentation.'
```
I then looked up the APIs docs [here](https://developer.signicat.com/express/apis/authentication.html#operation/CreateSession)
which clearly says, that one of the allowedProviders is indeed `ftn`.

After looking at the APIs docs, I then forced the `allowedProviders`
(with @ts-ignore) to be `['ftn']` and the API responded, as it should with `id`, `url` etc.

Assuming the `fi_eid` is the older version before `ftn`, why
is it still declared (wrong, from the APIs' standpoint) as it is?